### PR TITLE
Support ARCSAT observatory images and add console script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
 from setuptools import setup
 
-setup()
+setup(
+    entry_points={
+        "console_scripts": [
+            "koffi = koffi.script:main"
+        ]
+    }
+)

--- a/src/koffi/koffi.py
+++ b/src/koffi/koffi.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from koffi_tools.image_metadata import *
 from koffi_tools.potential_source import *
 
-
 def skybot_search_frame(image):
     """
     Gets all known objects within the frame of a single FITS image from SkyBoT.
@@ -162,7 +161,7 @@ def create_jpl_query_string(image):
 
     # Create a string of data for the observatory.
     if image.obs_code:
-        obs_str = "mpc-code=%s" % self.obs_code
+        obs_str = "mpc-code=%s" % image.obs_code
     else:
         obs_str = "lat=%f&lon=%f&alt=%f" % (image.obs_lat, image.obs_long, image.obs_alt)
 
@@ -189,7 +188,7 @@ def create_jpl_query_string(image):
         dec_str = "fov-dec-lim=M%02i-%02i-%05.2f" % (-dec_dms_L[0], -dec_dms_L[1], -dec_dms_L[2])
     dec_dms_H = Angle(image.center.dec + image.dec_radius()).dms
     if dec_dms_H[0] >= 0:
-        dec_str = "%s,02i-%02i-%05.2f" % (dec_str, dec_dms_H[0], dec_dms_H[1], dec_dms_H[2])
+        dec_str = "%s,%02i-%02i-%05.2f" % (dec_str, dec_dms_H[0], dec_dms_H[1], dec_dms_H[2])
     else:
         dec_str = "%s,M%02i-%02i-%05.2f" % (dec_str, -dec_dms_H[0], -dec_dms_H[1], -dec_dms_H[2])
 
@@ -222,6 +221,9 @@ def jpl_search_frame(image):
     with libreq.urlopen(query_string) as url:
         feed = url.read().decode("utf-8")
         results = json.loads(feed)
+
+        if 'warning' in results.keys() and results['warning'] == "no matching records":
+            return []
 
         num_results = results["n_second_pass"]
         for item in results["data_second_pass"]:

--- a/src/koffi/script.py
+++ b/src/koffi/script.py
@@ -1,0 +1,48 @@
+from .koffi import ImageMetadata, skybot_search_frame, jpl_search_frame
+from astropy.table import QTable
+from astropy import units as u
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("filename", type=str, help="The fits filts to open")
+    parser.add_argument("--query", type=str, default="JPL", help="The service to query, JPL or SkyBot")
+    parser.add_argument("--format", type=str, default="QTable", help="The output format to use")
+
+    args = parser.parse_args()
+
+    image = ImageMetadata(args.filename)
+
+    if args.query == "JPL":
+        search = jpl_search_frame
+    elif args.query == "SkyBot":
+        search = skybot_search_frame
+
+    objects = search(image)
+    names = []
+    ras = []
+    decs = []
+    xs = []
+    ys = []
+    for name, coord in objects:
+        names.append(name)
+        ras.append(coord.ra.degree * u.degree)
+        decs.append(coord.dec.degree * u.degree)
+        x, y = image.wcs.world_to_pixel(coord)
+        xs.append(x)
+        ys.append(y)
+
+    table = QTable(
+        data=[names, ras, decs, xs, ys], 
+        names=["Object Name", "RA", "Dec", "x", "y"],
+    )
+    if args.format == "QTable":
+        print(table)
+    else:
+        table.write(sys.stdout, format=args.format)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I ran into some issues using `koffi` out of the box with images from the ARCSAT observatory. I looked into them and implemented some bug fixes and functionality changes so that `koffi` works with these images and in a workflow suitable for me.

The bug fixes are a few typos in the code and when specifying fits headers.

The changes include:
1. querying for the MPC list of observatories and checking if the `OBSERVAT` header matches an MPC obs-code before using it, falling back to observatory longitude and altitude.
2. Using the `DATE-OBS` and `EXPTIME` headers to compute the observation time (as observation start + half the exposure time) in case `DATE-AVG` or the `mjd_key` are not available. (ARCSAT sets the `JD` header instead).
3. Returning no objects if there are none in the field (interpreting the JPL query results)
4. Creating a console script so that `koffi` can be used as an executable on the command line with reasonable printing, like so:
```
$ koffi ./decam/calexp_DECam_VR_VR_DECam_c0007_6300_0_2600_0_1031745_S29_steven_bad_mask_B1a_20210909_step1_20230422T062824Z.fits --query JPL
    Object Name             RA                 Dec                  x                  y         
                           deg                 deg                                               
------------------- ------------------ ------------------- ------------------- ------------------
191962 (2005 UJ483)  351.4052083333333  -4.090527777777777 -508.68617785163644 2011.7077708054658
290566 (2005 UH115) 351.37641666666667 -4.1730833333333335   626.3775356202042 1618.8031201806855
 308715 (2006 GT36) 351.46904166666667  -4.106777777777777  -286.3405338958438  2881.786867739447
577486 (2013 EX118)  351.3792083333333  -4.170583333333334   592.0096278015878 1656.7991577724874
        (2015 BW18)  351.4807083333333  -4.060861111111111  -919.8912384145148  3046.138852885603

```
`x` and `y` are the pixel locations of the objects and are valuable for followup. Note that `koffi` may want to filter out objects that land outside of the bounds of the CCD, which three of these do with negative pixel values. Machine readable formats can be printed using e.g. `--format csv`.